### PR TITLE
Fix website URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
     <p class="subtitle">Supporters</p>
 
     <p class="blocktext">
-        Thanks to <a href="travisscholten.com"> Travis Scholten</a> for helping source and review applications!
+        Thanks to <a href="http://travisscholten.com"> Travis Scholten</a> for helping source and review applications!
     </p>
 
     <p class="blocktext">


### PR DESCRIPTION
Fixes the URL for Travis' website to link to the site. Previous link is interpreted as a sub-page within the Unitary Fund site.